### PR TITLE
REALMC-12348: Add confirmation prompt on push createNewApp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/briandowns/spinner v1.12.0
 	github.com/edaniels/digest v0.0.0-20170923160545-b81e9c4ee11c
-	github.com/edaniels/golinters v0.0.3
+	github.com/edaniels/golinters v0.0.3 // indirect
 	github.com/fatih/color v1.10.0
-	github.com/golangci/golangci-lint v1.32.2
+	github.com/golangci/golangci-lint v1.32.2 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174
 	github.com/iancoleman/orderedmap v0.1.0
-	github.com/kr/pretty v0.2.1
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/spf13/afero v1.1.2

--- a/internal/commands/app/init_inputs_test.go
+++ b/internal/commands/app/init_inputs_test.go
@@ -20,7 +20,7 @@ func TestAppInitInputsResolve(t *testing.T) {
 		defer teardown()
 
 		assert.Nil(t, ioutil.WriteFile(
-			filepath.Join(profile.WorkingDirectory, local.FileConfig.String()),
+			filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()),
 			[]byte(fmt.Sprintf(`{"config_version": %d, "name":"eggcorn"}`, realm.DefaultAppConfigVersion)),
 			0666,
 		))

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -169,7 +169,7 @@ func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.C
 			return nil
 		}
 
-		newApp, proceed, err := createNewApp(ui, clients.Realm, cmd.inputs.LocalPath, appRemote.GroupID, app.AppData)
+		newApp, proceed, err := createNewApp(ui, clients.Realm, app.RootDir, appRemote.GroupID, app.AppData)
 		if err != nil {
 			return err
 		}
@@ -392,6 +392,7 @@ type namer interface{ Name() string }
 type locationer interface{ Location() realm.Location }
 type deploymentModeler interface{ DeploymentModel() realm.DeploymentModel }
 type environmenter interface{ Environment() realm.Environment }
+type configVersioner interface{ ConfigVersion() realm.AppConfigVersion }
 
 func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupID string, appData interface{}) (realm.App, bool, error) {
 	if proceed, err := ui.Confirm("Do you wish to create a new app?"); err != nil {
@@ -401,6 +402,7 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 	}
 
 	var name, location, deploymentModel, environment string
+	appConfigVersion := realm.DefaultAppConfigVersion
 	if appData != nil {
 		if n, ok := appData.(namer); ok {
 			name = n.Name()
@@ -416,6 +418,10 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 
 		if e, ok := appData.(environmenter); ok {
 			environment = e.Environment().String()
+		}
+
+		if cv, ok := appData.(configVersioner); ok {
+			appConfigVersion = cv.ConfigVersion()
 		}
 	}
 
@@ -475,7 +481,7 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 		return realm.App{}, false, err
 	}
 
-	if err := local.AsApp(appDirectory, app, realm.DefaultAppConfigVersion).WriteConfig(); err != nil {
+	if err := local.AsApp(appDirectory, app, appConfigVersion).WriteConfig(); err != nil {
 		return realm.App{}, false, err
 	}
 	return app, true, nil

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -468,6 +468,12 @@ func createNewApp(ui terminal.UI, realmClient realm.Client, appDirectory, groupI
 		}
 	}
 
+	if proceed, err := ui.Confirm("Are these settings correct?"); err != nil {
+		return realm.App{}, false, err
+	} else if !proceed {
+		return realm.App{}, false, nil
+	}
+
 	app, err := realmClient.CreateApp(
 		groupID,
 		name,

--- a/internal/commands/push/command.go
+++ b/internal/commands/push/command.go
@@ -259,12 +259,14 @@ func (cmd *Command) Handler(profile *user.Profile, ui terminal.UI, clients cli.C
 		return nil
 	}
 
-	proceed, err := ui.Confirm("Please confirm the changes shown above")
-	if err != nil {
-		return err
-	}
-	if !proceed {
-		return nil
+	if !isNewApp {
+		proceed, err := ui.Confirm("Please confirm the changes shown above")
+		if err != nil {
+			return err
+		}
+		if !proceed {
+			return nil
+		}
 	}
 
 	if len(appDiffs) > 0 {

--- a/internal/commands/push/command_test.go
+++ b/internal/commands/push/command_test.go
@@ -1220,6 +1220,9 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						c.Send(string(terminal.KeyArrowDown))
 						c.SendLine("")
 
+						c.ExpectString("Are these settings correct?")
+						c.SendLine("y")
+
 						c.ExpectEOF()
 					},
 					test: func(t *testing.T, configPath string) {
@@ -1245,6 +1248,38 @@ func TestPushCommandCreateNewApp(t *testing.T) {
 						},
 					},
 					expectedProceed: true,
+				},
+				{
+					description: "should not create app if user does not confirm configuration",
+					procedure: func(c *expect.Console) {
+
+						c.ExpectString("Do you wish to create a new app?")
+						c.SendLine("y")
+
+						c.ExpectString("App Name")
+						c.SendLine("testApp")
+
+						c.ExpectString("App Location")
+						c.Send(string(terminal.KeyArrowDown))
+						c.SendLine("")
+
+						c.ExpectString("App Deployment Model")
+						c.Send(string(terminal.KeyArrowDown))
+						c.SendLine("")
+
+						c.ExpectString("App Environment")
+						c.Send(string(terminal.KeyArrowDown))
+						c.SendLine("")
+
+						c.ExpectString("Are these settings correct?")
+						c.SendLine("")
+
+						c.ExpectEOF()
+					},
+					test: func(t *testing.T, configPath string) {
+						_, err := os.Stat(configPath)
+						assert.True(t, os.IsNotExist(err), "expected config path to not exist, but err was: %s", err)
+					},
 				},
 				{
 					description: "should still prompt for name with all missing data but auto confirm set to true",

--- a/internal/commands/push/inputs_test.go
+++ b/internal/commands/push/inputs_test.go
@@ -71,7 +71,7 @@ func TestPushInputsResolve(t *testing.T) {
 		defer teardown()
 
 		assert.Nil(t, ioutil.WriteFile(
-			filepath.Join(profile.WorkingDirectory, local.FileConfig.String()),
+			filepath.Join(profile.WorkingDirectory, local.FileRealmConfig.String()),
 			[]byte(fmt.Sprintf(`{"config_version": %d, "app_id": "eggcorn-abcde", "name":"eggcorn"}`, realm.DefaultAppConfigVersion)),
 			0666,
 		))

--- a/internal/local/app_test.go
+++ b/internal/local/app_test.go
@@ -205,6 +205,13 @@ func TestFindApp(t *testing.T) {
 				assert.Nil(t, err)
 				assert.False(t, foundApp, "should not be found")
 			})
+
+			t.Run("and a mismatched version in the config file should fail to find app", func(t *testing.T) {
+				path := filepath.Join(testRoot, "mismatch_version")
+				_, foundApp, err := FindApp(path)
+				assert.Nil(t, err)
+				assert.False(t, foundApp, "should not be found")
+			})
 		})
 	}
 }
@@ -376,7 +383,7 @@ func TestAppWrite20180301(t *testing.T) {
 
 		assert.Nil(t, app.Write())
 
-		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileRealmConfig.String()))
+		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileStitch.String()))
 		assert.Nil(t, readErr)
 
 		var config AppStitchJSON
@@ -434,17 +441,17 @@ func TestAppWrite20200603(t *testing.T) {
 		assert.Nil(t, err)
 		defer cleanupTmpDir()
 
-		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20180301)
+		app := NewApp(tmpDir, "test-app-abcde", "test-app", realm.LocationIreland, realm.DeploymentModelLocal, realm.EnvironmentDevelopment, realm.AppConfigVersion20200603)
 
 		assert.Nil(t, app.Write())
 
-		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileRealmConfig.String()))
+		data, readErr := ioutil.ReadFile(filepath.Join(tmpDir, FileConfig.String()))
 		assert.Nil(t, readErr)
 
 		var config AppConfigJSON
 		assert.Nil(t, json.Unmarshal(data, &config))
 		assert.Equal(t, AppConfigJSON{AppDataV1{AppStructureV1{
-			ConfigVersion:        realm.AppConfigVersion20180301,
+			ConfigVersion:        realm.AppConfigVersion20200603,
 			ID:                   "test-app-abcde",
 			Name:                 "test-app",
 			Location:             realm.LocationIreland,
@@ -506,7 +513,7 @@ func TestAppWrite20210101(t *testing.T) {
 		var config AppRealmConfigJSON
 		assert.Nil(t, json.Unmarshal(data, &config))
 		assert.Equal(t, AppRealmConfigJSON{AppDataV2{AppStructureV2{
-			ConfigVersion:   realm.DefaultAppConfigVersion,
+			ConfigVersion:   realm.AppConfigVersion20210101,
 			ID:              "test-app-abcde",
 			Name:            "test-app",
 			Location:        realm.LocationIreland,

--- a/internal/local/testdata/20180301/mismatch_version/stitch.json
+++ b/internal/local/testdata/20180301/mismatch_version/stitch.json
@@ -1,0 +1,26 @@
+
+{
+  "config_version": 20210101,
+  "name": "20180301-mismatch",
+  "location": "US-VA",
+  "deployment_model": "GLOBAL",
+  "security": {
+      "allowed_request_origins": [
+          "http://localhost:8080"
+      ]
+  },
+  "hosting": {
+      "enabled": true,
+      "app_default_domain": "full-tkdcx.stitch-statichosting-dev.baas-dev.10gen.cc"
+  },
+  "custom_user_data_config": {
+      "enabled": true,
+      "mongo_service_name": "mongodb-atlas",
+      "database_name": "test",
+      "collection_name": "coll3",
+      "user_id_field": "xref"
+  },
+  "sync": {
+      "development_mode_enabled": false
+  }
+}

--- a/internal/local/testdata/20200603/mismatch_version/config.json
+++ b/internal/local/testdata/20200603/mismatch_version/config.json
@@ -1,0 +1,25 @@
+{
+  "config_version": 20210101,
+  "name": "20200603-mismatch",
+  "location": "US-VA",
+  "deployment_model": "GLOBAL",
+  "security": {
+      "allowed_request_origins": [
+          "http://localhost:8080"
+      ]
+  },
+  "hosting": {
+      "enabled": true,
+      "app_default_domain": "full-tkdcx.stitch-statichosting-dev.baas-dev.10gen.cc"
+  },
+  "custom_user_data_config": {
+      "enabled": true,
+      "mongo_service_name": "mongodb-atlas",
+      "database_name": "test",
+      "collection_name": "coll3",
+      "user_id_field": "xref"
+  },
+  "sync": {
+      "development_mode_enabled": false
+  }
+}

--- a/internal/local/testdata/20210101/mismatch_version/realm_config.json
+++ b/internal/local/testdata/20210101/mismatch_version/realm_config.json
@@ -1,0 +1,9 @@
+{
+  "config_version": 20200603,
+  "name": "20210101-mismatch",
+  "location": "US-VA",
+  "deployment_model": "GLOBAL",
+  "allowed_request_origins": [
+    "http://localhost:8080"
+  ]
+}


### PR DESCRIPTION
When creating a new app using the push command, we should give the user an opportunity to approve the configuration they've specified in the CLI.

At the same time, we don't need to confirm diff changes when creating a new app, since there's no remote app to compare diff against.

I'm merging this commit into REALMC-11800 for now but will retarget to master once that ticket is closed.